### PR TITLE
skiping special chars for bash env -- KEEP_PUNCT

### DIFF
--- a/envs/env
+++ b/envs/env
@@ -19,7 +19,7 @@ MAX_SKIP_TKN=2
 
 LR=1
 ANNEAL=True
-KEEP_PUNCT=:|.
+KEEP_PUNCT=\:\|\.
 
 SPACY_MODEL=en_core_sci_md
 


### PR DESCRIPTION
When trying to load `KEEP_PUNCT` env:
```
> source envs/env_medcat_umls
envs/env_medcat_umls:.:21: not enough arguments
```
Need to escape the special characters.