### PR TITLE
CU-862j7vgz9: fix escaping of entity render template

### DIFF
--- a/webapp/frontend/src/components/common/ClinicalText.vue
+++ b/webapp/frontend/src/components/common/ClinicalText.vue
@@ -93,7 +93,7 @@ export default {
       // escape '<' '>' that may be interpreted as start/end tags, escape inserted span tags.
       formattedText = formattedText
         .replace(/<(?!\/?span)/g, '&lt')
-        .replace(/(?<!<span @click="selectEnt\(\d\)".*"|\/span)>/g, '&gt')
+        .replace(/(?<!<span @click="selectEnt\(\d\d?\d?\d?\)".*"|\/span)>/g, '&gt')
 
       formattedText = this.addAnnos ? `<div @contextmenu.prevent.stop="showCtxMenu($event)">${formattedText}</div>` : `<div>${formattedText}</div>`
       this.scrollIntoView(timeout)


### PR DESCRIPTION
Fix for an issue of incorrect escaping of the clinical text template for MedCAT annotated entities where there are double digit (more than 9) entities. 

Somehow this regex works as intended on MacOS Chrome v110.x but fails (as it actually should on) (windows) Chrome v109.x builds. 

Server send rendering would be a long term fix here - as returned medcat annotations could be directly replace the text rather than iteratively searching through medcat returned indices...
