### PR TITLE
Cu 862j1wq35 default user group

### DIFF
--- a/webapp/scripts/create_group.py
+++ b/webapp/scripts/create_group.py
@@ -1,0 +1,14 @@
+from django.contrib.auth.models import Group, Permission
+from itertools import chain
+
+print("Checking for Default User Group")
+group, created = Group.objects.get_or_create(name='user_group')
+if created:
+    print("No Default User Group Found - Creating with Permissions")
+dataset = list(Permission.objects.filter(codename__contains='dataset').exclude(codename__contains='delete'))
+concept = list(Permission.objects.filter(codename__contains='concept'))
+project = list(Permission.objects.filter(codename__contains="projectannotateentities").exclude(codename__contains="delete"))
+permissions = chain(dataset, concept, project)
+for p in permissions:
+    group.permissions.add(p)
+print("User_group created with minimum correct permissions")

--- a/webapp/scripts/run.sh
+++ b/webapp/scripts/run.sh
@@ -18,9 +18,15 @@ python /home/api/manage.py process_tasks --log-std &
 
 # create a new super user, with username and password 'admin'
 echo "from django.contrib.auth import get_user_model
+from django.contrib.auth.models import User, Group, Permission
 User = get_user_model()
 if User.objects.count() == 0:
     User.objects.create_superuser('admin', 'admin@example.com', 'admin')
+    user = User.objects.create_user('username', 'username@example.com', 'password')
+    permissions = Permission.objects.exclude(codename__contains="delete")
+    group = Group.objects.get_or_create(name='user_group')
+    group.permissions.add(permissions)
+    group.user_set.add(user)
 " | python manage.py shell
 
 if [ $LOAD_EXAMPLES ]; then

--- a/webapp/scripts/run.sh
+++ b/webapp/scripts/run.sh
@@ -23,10 +23,11 @@ User = get_user_model()
 if User.objects.count() == 0:
     User.objects.create_superuser('admin', 'admin@example.com', 'admin')
     user = User.objects.create_user('username', 'username@example.com', 'password')
-    permissions = Permission.objects.exclude(codename__contains="delete")
-    group = Group.objects.get_or_create(name='user_group')
-    group.permissions.add(permissions)
+    group = Group.objects.get_or_create(name='user_group')[0]
     group.user_set.add(user)
+    permissions = Permission.objects.exclude(codename__contains='delete')
+    for p in permissions:
+      group.permissions.add(p)
 " | python manage.py shell
 
 if [ $LOAD_EXAMPLES ]; then

--- a/webapp/scripts/run.sh
+++ b/webapp/scripts/run.sh
@@ -19,22 +19,17 @@ python /home/api/manage.py process_tasks --log-std &
 # create a new super user, with username and password 'admin'
 # also create a user group `user_group` that prevents users from deleting models
 echo "from django.contrib.auth import get_user_model
-from django.contrib.auth.models import User, Group, Permission
 User = get_user_model()
 if User.objects.count() == 0:
     User.objects.create_superuser('admin', 'admin@example.com', 'admin')
-group, created = Group.objects.get_or_create(name='user_group')
-if created:
-    user = User.objects.create_user('username', 'username@example.com', 'password')
-    group.user_set.add(user)
-    permissions = Permission.objects.exclude(codename__contains='delete')
-    for p in permissions:
-      group.permissions.add(p)
 " | python manage.py shell
 
 if [ $LOAD_EXAMPLES ]; then
   python /home/scripts/load_examples.py &
 fi
+
+# Creating a default user group that can manage projects and annotate but not delete
+python manage.py shell < /home/scripts/create_group.py
 
 # RESET any Env vars to original stat
 export RESUBMIT_ALL_ON_STARTUP=$TMP_RESUBMIT_ALL_VAR

--- a/webapp/scripts/run.sh
+++ b/webapp/scripts/run.sh
@@ -17,13 +17,15 @@ python /home/api/manage.py migrate api --noinput
 python /home/api/manage.py process_tasks --log-std &
 
 # create a new super user, with username and password 'admin'
+# also create a user group `user_group` that prevents users from deleting models
 echo "from django.contrib.auth import get_user_model
 from django.contrib.auth.models import User, Group, Permission
 User = get_user_model()
 if User.objects.count() == 0:
     User.objects.create_superuser('admin', 'admin@example.com', 'admin')
+group, created = Group.objects.get_or_create(name='user_group')
+if created:
     user = User.objects.create_user('username', 'username@example.com', 'password')
-    group = Group.objects.get_or_create(name='user_group')[0]
     group.user_set.add(user)
     permissions = Permission.objects.exclude(codename__contains='delete')
     for p in permissions:


### PR DESCRIPTION
This is the first commit of this change. There will be adjustments, and I'll list what they should be and the related questions.

1. I've edited the `webapp/scripts/run.sh` script where the admin permissions are given. Maybe this should be its own python script now to set up groups, permissions, and users. If so where would be ideal for it?
2. I've removed all permissions that contain the phrase `delete` which is a bit extreme... is there a solid list of permissions we want the average user to have / not have? I've also not saved the group as a member of staff - restricting their access to the admin page - would this be how we want it?
3. Do we want a default user to exist - or just the group?

Changes I know to make:

1. Create the group regardless of if any users exist
2. Add documentation that it's also creating a standard user group.