### PR TITLE
Metrics bug fixes / improvements

### DIFF
--- a/webapp/api/api/views.py
+++ b/webapp/api/api/views.py
@@ -698,7 +698,7 @@ def remove_metrics_job(request, report_id: int):
             pass
         task.delete()
         logger.info('Completed metrics job deleted - report ID: %s', report_id)
-        return Response(200, 'task / report deleted')
+        return Response('task / report deleted', 200)
 
 
 @api_view(http_method_names=['GET', 'PUT'])

--- a/webapp/api/api/views.py
+++ b/webapp/api/api/views.py
@@ -636,7 +636,7 @@ def metrics_jobs(request):
             return {
                 'report_id': task.id,
                 'report_name_generated': task.verbose_name,
-                'projects': task.verbose_name.split('-')[1].split(','),
+                'projects': task.verbose_name.split('-')[1].split('_'),
                 'created_user': task.creator.username,
                 'create_time': task.run_at.strftime(dt_fmt),
                 'status': state

--- a/webapp/frontend/src/router.js
+++ b/webapp/frontend/src/router.js
@@ -14,7 +14,7 @@ export default new Router({
   mode: 'history',
   routes: [
     {
-      path: '/train-annotations/:projectId/:docId',
+      path: '/train-annotations/:projectId/:docId?',
       name: 'train-annotations',
       component: TrainAnnotations,
       props: true,

--- a/webapp/frontend/src/styles/_common.scss
+++ b/webapp/frontend/src/styles/_common.scss
@@ -26,6 +26,12 @@
 $blur-radius: 10px;
 
 @each $i, $col in $task-colors {
+  .task-color-text-#{$i} {
+    color: $col;
+  }
+}
+
+@each $i, $col in $task-colors {
   .task-btn-#{$i} {
     border-color: $col;
     color: $col;

--- a/webapp/frontend/src/views/MetricsHome.vue
+++ b/webapp/frontend/src/views/MetricsHome.vue
@@ -113,6 +113,8 @@ export default {
   padding: 10px 0;
   width: 95%;
   margin: auto;
+  height: calc(100% - 100px);
+  overflow-y: auto;
 }
 
 .status-icon {

--- a/webapp/frontend/src/views/MetricsHome.vue
+++ b/webapp/frontend/src/views/MetricsHome.vue
@@ -9,7 +9,7 @@
              :select-mode="'single'"
              @row-selected="loadMetrics">
       <template #cell(projects)="data">
-        <div v-html="data.value"></div>
+        <v-runtime-template :template="data.value"></v-runtime-template>
       </template>
 
       <template #cell(status)="data">
@@ -48,12 +48,13 @@
 </template>
 
 <script>
+import VRuntimeTemplate from 'v-runtime-template'
 import LoadingOverlay from '@/components/common/LoadingOverlay.vue'
 import Modal from '@/components/common/Modal.vue'
 
 export default {
   name: "MetricsHome",
-  components: {Modal, LoadingOverlay },
+  components: {Modal, LoadingOverlay, VRuntimeTemplate,},
   props: {
   },
   data () {
@@ -89,7 +90,7 @@ export default {
           return item
         })
         this.fetchProjects()
-        setTimeout(this.pollReportStatus, 10000)
+        setTimeout(this.pollReportStatus, 5000)
       })
     },
     fetchProjects () {
@@ -124,7 +125,10 @@ export default {
       let outEl = ''
       value.forEach(i => {
         if (this.projects[i]) {
-          outEl += `<router-link to="train-annotations/${i}/">${this.projects[i].name}</router-link>`
+          outEl += `
+          <div>
+            <router-link :to="{ name: 'train-annotations', params: { projectId: '${i}' }}">${this.projects[i].name}</router-link>
+          </div>`
         } else {
           outEl += `<div>${i}</div>`
         }
@@ -147,4 +151,14 @@ export default {
 .status-icon {
   padding-left: 3px;
 }
+
+.project-links {
+  color: #005EB8;
+
+  &:hover {
+    color: #fff;
+    border-bottom: 1px solid #fff;
+  }
+}
+
 </style>

--- a/webapp/frontend/src/views/MetricsHome.vue
+++ b/webapp/frontend/src/views/MetricsHome.vue
@@ -24,7 +24,8 @@
         </span>
       </template>
       <template #cell(cleanup)="data">
-        <button class="btn btn-outline-danger" @click="confDeleteReportModal = data.item">
+        <button class="btn btn-outline-danger" @click="confDeleteReportModal = data.item"
+                :disabled="data.item.status === 'pending' || data.item.status === 'running'">
           <font-awesome-icon icon="times"></font-awesome-icon>
         </button>
       </template>
@@ -130,7 +131,10 @@ export default {
             <router-link :to="{ name: 'train-annotations', params: { projectId: '${i}' }}">${this.projects[i].name}</router-link>
           </div>`
         } else {
-          outEl += `<div>${i}</div>`
+          outEl += `
+            <div>
+              ${i} <font-awesome-icon icon="spinner" spin></font-awesome-icon>
+            </div>`
         }
       })
       return `<div>${outEl}</div>`


### PR DESCRIPTION
Small improvements to the metrics report list page, and the report page

- Add a scroll to the table container
- Add project links back to each report
- Disable removing a running report (as this fails server side)
- Fix removing a complete or pending report on the report home page
- Add a annotation status on the 'Annotations' page. 

