### PR TITLE
CU-2nqa6pa: use stock nginx configured with conf / sites-enabled

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,5 +1,3 @@
-version: '3.4'
-
 # Dev compose yml file for building, running and mounting local git cloned repo.
 
 services:
@@ -26,13 +24,13 @@ services:
     command: /home/scripts/run.sh
 
   nginx:
-    build:
-      network: host
-      context: ./nginx
+    image: nginx
     restart: always
     volumes:
       - api-media:/home/api/media
       - api-static:/home/api/static
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf
+      - ./nginx/sites-enabled/:/etc/nginx/sites-enabled
     ports:
       - ${MCTRAINER_PORT:-8001}:8000
     depends_on:

--- a/docker-compose-mc0x.yml
+++ b/docker-compose-mc0x.yml
@@ -18,12 +18,13 @@ services:
       - ./envs/env-mc0x
     command: /home/run.sh
   nginx:
-    container_name: medcattrainer_nginx
-    image: cogstacksystems/medcat-trainer-nginx:mc-v0.x-latest
+    image: nginx
     restart: always
     volumes:
       - api-media:/home/api/media
       - api-static:/home/api/static
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf
+      - ./nginx/sites-enabled/:/etc/nginx/sites-enabled
     ports:
       - "${MCTRAINER_PORT:-8001}:8000"
     depends_on:

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,5 +1,3 @@
-version: '3.4'
-
 # Prod compose file -
 
 services:
@@ -39,11 +37,13 @@ services:
 
   nginx:
     container_name: medcattrainer_nginx
-    image: cogstacksystems/medcat-trainer-nginx:v2.16.0
+    image: nginx
     restart: always
     volumes:
       - api-media:/home/api/media
       - api-static:/home/api/static
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf
+      - ./nginx/sites-enabled/:/etc/nginx/sites-enabled
     ports:
       - "${MCTRAINER_PORT:-8001}:8000"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.4'
-
 # Default compose yml file - uses latest build of MedCATtrainer services. Default passwords and example
 # projects are not used.
 
@@ -35,11 +33,13 @@ services:
     command: cron -f -l 2
 
   nginx:
-    image: cogstacksystems/medcat-trainer-nginx:v2.16.0
+    image: nginx
     restart: always
     volumes:
       - api-media:/home/api/media
       - api-static:/home/api/static
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf
+      - ./nginx/sites-enabled/:/etc/nginx/sites-enabled
     ports:
       - ${MCTRAINER_PORT:-8001}:8000
     depends_on:

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,7 +1,0 @@
-FROM nginx
-# Add configuration
-RUN rm /etc/nginx/conf.d/default.conf
-ADD nginx.conf /etc/nginx/nginx.conf
-# Add site
-RUN mkdir /etc/nginx/sites-enabled/
-ADD sites-enabled/ /etc/nginx/sites-enabled


### PR DESCRIPTION
stock nginx docker image can be used with bind mounts for nginx.conf and the trainer site.
Updated all the versions to use stock docker.