### PR TITLE
Use envs

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -31,6 +31,8 @@ services:
       - api-static:/home/api/static
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf
       - ./nginx/sites-enabled/:/etc/nginx/sites-enabled
+    env_file:
+      - ./envs/env
     ports:
       - ${MCTRAINER_PORT:-8001}:8000
     depends_on:
@@ -41,6 +43,8 @@ services:
     container_name: mct_solr
     image: solr:8
     restart: always
+    env_file:
+      - ./envs/env
     ports:
       - ${SOLR_PORT:-8983}:8983
     volumes:

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -31,7 +31,7 @@ services:
       - api-db:/home/api/db
       - api-db-backup:/home/api/db-backup
     env_file:
-      - ./envs/env
+      - ./envs/env-prod
     entrypoint: /home/scripts/entry.sh
     command: cron -f -l 2
 
@@ -44,6 +44,8 @@ services:
       - api-static:/home/api/static
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf
       - ./nginx/sites-enabled/:/etc/nginx/sites-enabled
+    env_file:
+      - ./envs/env-prod
     ports:
       - "${MCTRAINER_PORT:-8001}:8000"
     depends_on:
@@ -54,6 +56,8 @@ services:
     container_name: mct_solr
     image: solr:8
     restart: always
+    env_file:
+      - ./envs/env-prod
     expose:
       - "8983"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,8 @@ services:
       - api-static:/home/api/static
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf
       - ./nginx/sites-enabled/:/etc/nginx/sites-enabled
+    env_file:
+      - ./envs/env
     ports:
       - ${MCTRAINER_PORT:-8001}:8000
     depends_on:
@@ -50,6 +52,8 @@ services:
     container_name: mct_solr
     image: solr:8
     restart: always
+    env_file:
+      - ./envs/env
     ports:
       - ${SOLR_PORT:-8983}:8983
     volumes:

--- a/envs/env
+++ b/envs/env
@@ -11,7 +11,7 @@ ENV=non-prod
 CSRF_TRUSTED_ORIGINS=
 
 ### Django debug setting - to live-reload etc. ###
-DEBUG=True
+DEBUG=1
 
 ### Load example CDB, Vocab ###
 LOAD_EXAMPLES=1
@@ -32,7 +32,7 @@ DB_PATH=${DB_DIR}/db.sqlite3
 DB_BACKUP_DIR=/home/api/db-backup
 
 # Resubmit all on startup
-RESUBMIT_ALL_ON_STARTUP=1
+RESUBMIT_ALL_ON_STARTUP=0
 
 # Front end env vars
 LOAD_NUM_DOC_PAGES=10

--- a/envs/env-prod
+++ b/envs/env-prod
@@ -12,7 +12,7 @@ ENV=prod
 CSRF_TRUSTED_ORIGINS=
 
 # Django Debug mode should be False for prod
-DEBUG=False
+DEBUG=0
 
 ### Load example CDB, Vocab ###
 LOAD_EXAMPLES=0

--- a/webapp/api/core/settings.py
+++ b/webapp/api/core/settings.py
@@ -38,9 +38,13 @@ else:
     SECRET_KEY = 'q$&esydgbn2=#-k5s5i(+^dtxs1@$50_(ln0wuw@zig4m&^m7='
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = os.environ.get('DEBUG', True)
-if realm == 'prod' and DEBUG:
-    log.warning('Running in prod realm with DEBUG=True, are you sure you want to do that?')
+try:
+    DEBUG = bool(int(os.environ.get('DEBUG', 1)))
+    if realm == 'prod' and DEBUG:
+        log.warning('Running in prod realm with DEBUG=True, are you sure you want to do that?')
+except ValueError as e:
+    log.error('Error parsing DEBUG env, setting DEBUG to True. DEBUG env var should be set to 0 (false) or 1 (true).')
+    DEBUG = True
 
 ALLOWED_HOSTS = ['*']
 


### PR DESCRIPTION
use the appropriate envs/env file for the docker-compose services. This has no effect right now, but was a little confusing when during last release I saw that some of the services did not have an env file set in the spec