### PR TITLE
CU-86973phjx: fix runtime compilation of templates to preserve whitespace

### DIFF
--- a/webapp/frontend/src/main.ts
+++ b/webapp/frontend/src/main.ts
@@ -65,4 +65,5 @@ app.use(vuetify);
   }
 })()
 
+app.config.compilerOptions.whitespace = 'preserve';
 app.mount('#app')


### PR DESCRIPTION
inconsistency in the vue3 docs, as discussed here: https://github.com/vuejs/core/pull/1600, requires this change.