### PR TITLE
Metrics graph and proj overlap

### DIFF
--- a/webapp/frontend/src/components/anns/TaskBar.vue
+++ b/webapp/frontend/src/components/anns/TaskBar.vue
@@ -41,7 +41,7 @@ export default {
     'submit'
   ],
   watch: {
-    'submitLocked' (oldVal, newVal) {
+    'submitLocked' (newVal) {
       if (newVal) {
         this.listenSubmit()
       } else {

--- a/webapp/frontend/src/components/common/ConceptFilter.vue
+++ b/webapp/frontend/src/components/common/ConceptFilter.vue
@@ -130,7 +130,7 @@ export default {
     }, 500)
   },
   watch: {
-    filter (newVal, oldVal) {
+    filter (newVal) {
       if (newVal.length > 0) {
         this.filterItems(newVal)
       } else {

--- a/webapp/frontend/src/components/common/ProjectList.vue
+++ b/webapp/frontend/src/components/common/ProjectList.vue
@@ -411,9 +411,14 @@ export default {
     pollDocPrepStatus () {
       this.$http.get('/api/prep-docs-bg-tasks/').then(resp => {
         this.completeBgTasks = new Set(resp.data.comp_tasks.map(d => d.project))
-        this.runningBgTasks = new Set([...this.runningBgTasks,
-          ...resp.data.running_tasks.map(d => d.project)]).difference(this.completeBgTasks)
-
+        const newRunningTasks = new Set([
+          ...this.runningBgTasks,
+          ...resp.data.running_tasks.map(d => d.project)
+        ])
+        for (const completedTask of this.completeBgTasks) {
+          newRunningTasks.delete(completedTask)
+        }
+        this.runningBgTasks = newRunningTasks
       })
       setTimeout(this.pollDocPrepStatus, 8000)
     }


### PR DESCRIPTION
- Fix bug where Set.prototype.Difference  isn't available in older browser versions
- Metrics overlap is now calculated from document.name, rather than doc.id - this is stated in the accompanying tooltips
- graph re-renders when switching to and from summary_stats tab