### PR TITLE
Fix model loading, cacheing and error handling

### DIFF
--- a/webapp/api/api/model_cache.py
+++ b/webapp/api/api/model_cache.py
@@ -102,18 +102,23 @@ def get_medcat(project,
 
 
 def get_cached_medcat(project, cat_map: Dict[str, CAT]=CAT_MAP):
-    if project.concept_db is None or project.vocab is None:
-        return None
-    cdb_id = project.concept_db.id
-    vocab_id = project.vocab.id
-    cat_id = str(cdb_id) + "-" + str(vocab_id)
+    if project.model_pack is not None:
+        cat_id = 'mp' + str(project.model_pack.id)
+    else:
+        cdb_id = project.concept_db.id
+        vocab_id = project.vocab.id
+        cat_id = str(cdb_id) + "-" + str(vocab_id)
     return cat_map.get(cat_id)
 
 
 def clear_cached_medcat(project, cat_map: Dict[str, CAT]=CAT_MAP):
-    cdb_id = project.concept_db.id
-    vocab_id = project.vocab.id
-    cat_id = str(cdb_id) + "-" + str(vocab_id)
+    if project.model_pack is not None:
+        model_pack_obj = project.model_pack
+        cat_id = 'mp' + str(model_pack_obj.id)
+    else:
+        cdb_id = project.concept_db.id
+        vocab_id = project.vocab.id
+        cat_id = str(cdb_id) + "-" + str(vocab_id)
     if cat_id in cat_map:
         del cat_map[cat_id]
 

--- a/webapp/api/api/model_cache.py
+++ b/webapp/api/api/model_cache.py
@@ -25,11 +25,11 @@ logger = logging.getLogger(__name__)
 def _clear_models(cdb_map: Dict[str, CDB]=CDB_MAP,
                   vocab_map: Dict[str, Vocab]=VOCAB_MAP,
                   cat_map: Dict[str, CAT]=CAT_MAP):
-    if len(cat_map) == _MAX_MODELS_LOADED:
+    if len(cat_map) > _MAX_MODELS_LOADED:
         (k := next(iter(cat_map)), cat_map.pop(k))
-    if len(cdb_map) == _MAX_MODELS_LOADED:
+    if len(cdb_map) > _MAX_MODELS_LOADED:
         (k := next(iter(cdb_map)), cdb_map.pop(k))
-    if len(vocab_map) == _MAX_MODELS_LOADED:
+    if len(vocab_map) > _MAX_MODELS_LOADED:
         (k := next(iter(vocab_map)), vocab_map.pop(k))
 
 
@@ -118,6 +118,8 @@ def clear_cached_medcat(project, cat_map: Dict[str, CAT]=CAT_MAP):
     else:
         cdb_id = project.concept_db.id
         vocab_id = project.vocab.id
+        clear_cached_cdb(cdb_id)
+        clear_cached_vocab(vocab_id)
         cat_id = str(cdb_id) + "-" + str(vocab_id)
     if cat_id in cat_map:
         del cat_map[cat_id]
@@ -134,6 +136,11 @@ def get_cached_cdb(cdb_id: str, cdb_map: Dict[str, CDB]=CDB_MAP) -> CDB:
 def clear_cached_cdb(cdb_id, cdb_map: Dict[str, CDB]=CDB_MAP):
     if cdb_id in cdb_map:
         del cdb_map[cdb_id]
+
+
+def clear_cached_vocab(vocab_id, vocab_map: Dict[str, Vocab]=VOCAB_MAP):
+    if vocab_id in vocab_map:
+        del vocab_map[vocab_id]
 
 
 def is_model_loaded(project,

--- a/webapp/api/api/views.py
+++ b/webapp/api/api/views.py
@@ -704,7 +704,7 @@ def cache_model(request, project_id):
                 return Response('success', 200)
         elif request.method == 'DELETE':
             if is_loaded:
-                clear_cached_medcat(project_id)
+                clear_cached_medcat(project)
             return Response('success', 200)
         else:
             return Response(f'Invalid method', 404)
@@ -721,7 +721,7 @@ def model_loaded(_):
     for p in ProjectAnnotateEntities.objects.all():
         models_loaded[p.id] = is_model_loaded(p)
 
-    return Response(models_loaded)
+    return Response({'model_states': models_loaded})
 
 
 @api_view(http_method_names=['GET', 'POST'])

--- a/webapp/api/core/urls.py
+++ b/webapp/api/core/urls.py
@@ -49,7 +49,7 @@ urlpatterns = [
     path('api/project-progress/', api.views.project_progress),
     path('api/concept-db-search-index-created/', api.views.concept_search_index_available),
     path('api/model-loaded/', api.views.model_loaded),
-    path('api/cache-model/<int:cdb_id>/', api.views.cache_model),
+    path('api/cache-model/<int:project_id>/', api.views.cache_model),
     path('api/upload-deployment/', api.views.upload_deployment),
     path('api/model-concept-children/<int:cdb_id>/', api.views.cdb_cui_children),
     path('api/metrics/<int:report_id>/', api.views.view_metrics),

--- a/webapp/frontend/src/components/common/ClinicalText.vue
+++ b/webapp/frontend/src/components/common/ClinicalText.vue
@@ -143,7 +143,7 @@ export default {
     },
     showCtxMenu  (event) {
       const selection = window.getSelection()
-      const selStr = selection.toString()
+      const selStr = selection.toString().trim()
       const anchor = selection.anchorNode
       const focus = selection.focusNode
 

--- a/webapp/frontend/src/components/common/ProjectList.vue
+++ b/webapp/frontend/src/components/common/ProjectList.vue
@@ -11,13 +11,15 @@
         <span class="overlay-message">Loading Projects...</span>
       </v-overlay>
       <v-data-table id="projectTable"
+                    :key="tableKey"
                     :headers="isAdmin ? projects.headers : projects.headers.filter(f => projects.adminOnlyFields.indexOf(f.value) === -1)"
                     :items="projectItems"
                     :hover="true"
+                    :items-per-page="-1"
+                    :row-props="availableProjectForMetrics"
                     v-if="!loadingProjects"
                     @click:row="select"
-                    hide-default-footer
-                    :items-per-page="-1">
+                    hide-default-footer>
         <template #header.metrics>
           Metrics
           <v-tooltip activator="parent">
@@ -135,6 +137,11 @@
                     @click="selectProject(item)">
               <font-awesome-icon icon="fa-chart-pie"></font-awesome-icon>
             </button>
+            <v-tooltip activator="parent">
+              Once selected, only projects <br>
+              configured to use the same MedCAT <br>
+              model will be available
+            </v-tooltip>
           </div>
         </template>
         <template #item.save_model="{ item }">
@@ -238,6 +245,7 @@ export default {
   },
   data () {
     return {
+      tableKey: 0,
       projects: {
         headers: [
           { value: 'locked', title: ''},
@@ -313,6 +321,15 @@ export default {
         this.selectedProjects.splice(this.selectedProjects.indexOf(project), 1)
       } else {
         this.selectedProjects.push(project)
+      }
+      this.tableKey++
+    },
+    availableProjectForMetrics (data) {
+      if (this.selectedProjects.length === 0) {
+        return {class: ''}
+      } else {
+        let disabled = this.selectedProjects[0].id !== data.item.id
+        return {class: disabled ? ' disabled-row' : ''}  
       }
     },
     submitMetricsReportReq () {
@@ -547,4 +564,9 @@ export default {
   }
 }
 
+:deep(.v-table > .v-table__wrapper > table > tbody > tr.disabled-row) {
+  pointer-events: none;
+  opacity: 0.5;
+  background-color: #f0f0f0;
+}
 </style>

--- a/webapp/frontend/src/components/common/ProjectList.vue
+++ b/webapp/frontend/src/components/common/ProjectList.vue
@@ -328,7 +328,9 @@ export default {
       if (this.selectedProjects.length === 0) {
         return {class: ''}
       } else {
-        let disabled = this.selectedProjects[0].id !== data.item.id
+        let disabled = !(this.selectedProjects[0].concept_db === data.item.concept_db && 
+                        this.selectedProjects[0].vocab === data.item.vocab) ||
+                        this.selectedProjects[0].model_pack !== data.item.model_pack
         return {class: disabled ? ' disabled-row' : ''}  
       }
     },

--- a/webapp/frontend/src/views/Home.vue
+++ b/webapp/frontend/src/views/Home.vue
@@ -29,12 +29,12 @@
         </template>
         <template #body>
           <project-list :project-items="selectedProjectGroup.items" :is-admin="isAdmin"
-                        :cdb-search-index-status="cdbSearchIndexStatus" :cdb-loaded="cdbLoaded"></project-list>
+                        :cdb-search-index-status="cdbSearchIndexStatus"></project-list>
         </template>
       </modal>
     </div>
     <project-list v-if="!projectGroupView" :project-items="projects.items" :is-admin="isAdmin"
-                  :cdb-search-index-status="cdbSearchIndexStatus" :cdb-loaded="cdbLoaded"></project-list>
+                  :cdb-search-index-status="cdbSearchIndexStatus"></project-list>
   </div>
 
 </template>
@@ -73,8 +73,7 @@ export default {
       loadingProjects: false,
       isAdmin: false,
       selectedProjectGroup: null,
-      cdbSearchIndexStatus: {},
-      cdbLoaded: {},
+      cdbSearchIndexStatus: {}
     }
   },
   created () {
@@ -145,17 +144,12 @@ export default {
       })
     },
     postLoadedProjects () {
-      this.fetchCDBsLoaded()
       this.fetchSearchIndexStatus()
       this.fetchProjectProgress()
       this.fetchProjectGroups()
       this.loadingProjects = false
     },
-    fetchCDBsLoaded () {
-      this.$http.get('/api/model-loaded/').then(resp => {
-        this.cdbLoaded = resp.data
-      })
-    },
+
     fetchSearchIndexStatus () {
       const cdbIds = _.uniq(this.projects.items.map(p => p.cdb_search_filter[0])).filter(id => id)
       this.$http.get(`/api/concept-db-search-index-created/?cdbs=${cdbIds.join(',')}`).then(resp => {

--- a/webapp/frontend/src/views/Home.vue
+++ b/webapp/frontend/src/views/Home.vue
@@ -157,7 +157,7 @@ export default {
       })
     },
     fetchSearchIndexStatus () {
-      const cdbIds = _.uniq(this.projects.items.map(p => p.cdb_search_filter[0]))
+      const cdbIds = _.uniq(this.projects.items.map(p => p.cdb_search_filter[0])).filter(id => id)
       this.$http.get(`/api/concept-db-search-index-created/?cdbs=${cdbIds.join(',')}`).then(resp => {
         this.cdbSearchIndexStatus = resp.data.results
       }).catch(err => {

--- a/webapp/frontend/src/views/TrainAnnotations.vue
+++ b/webapp/frontend/src/views/TrainAnnotations.vue
@@ -492,7 +492,7 @@ export default {
         this.fetchEntities()
       } else {
         this.loadingMsg = "Loading MedCAT model..."
-        this.$http.get(`/api/cache-model/${this.project.concept_db}/`).then(_ => {
+        this.$http.get(`/api/cache-model/${this.project.id}/`).then(_ => {
           this.loadingMsg = "Preparing Document..."
           let payload = {
             project_id: this.project.id,

--- a/webapp/frontend/src/views/TrainAnnotations.vue
+++ b/webapp/frontend/src/views/TrainAnnotations.vue
@@ -512,9 +512,10 @@ export default {
               this.errors.stacktrace = err.response.data.stacktrace
             }
           })
-        }).catch(_ => {
+        }).catch(e => {
           this.errors.modal = true
-          this.errors.mesasge = "Internal server error - cannot load MedCAT model. Contact your MedCAT admin quoting this project ID"
+          this.errors.description = e.response?.data?.message || 'Internal server error - cannot load MedCAT model. Contact your MedCAT admin quoting this project ID'
+          this.errors.message = 'Failed to load MedCAT Model'
         })
       }
     },


### PR DESCRIPTION
as models are lazy loaded now on add-term calls or loading docs not previously run over, and now model packs are available this refactors all model cache, load calls to use the `project.model` - which is actually a combo of either `project.concept_db` and `project.vocab` or `project.model_pack`