### PR TITLE
CU-8699mth6q: prefix with supervisord program name

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -5,7 +5,7 @@ logfile=/var/log/supervisord.log
 pidfile=/var/run/supervisord.pid
 
 [program:medcattrainer]
-command=/home/scripts/run.sh
+command=sh -c "exec /home/scripts/run.sh 2>&1 | sed 's/^/[medcattrainer] /'"
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
@@ -13,7 +13,7 @@ stderr_logfile_maxbytes=0
 autorestart=true
 
 [program:bg-process]
-command=/home/scripts/run-bg-process.sh
+command=sh -c "exec /home/scripts/run-bg-process.sh 2>&1 | sed 's/^/[bg-process] /'"
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
@@ -21,9 +21,9 @@ stderr_logfile_maxbytes=0
 autorestart=true
 
 [program:db-backup]
-command=cron -f -l 2
+command=sh -c "exec cron -f -l 2 2>&1 | sed 's/^/[db-backup] /'"
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
-autorestart=true 
+autorestart=true


### PR DESCRIPTION
All supervisord managed processes log to stdout / stderr

Change to enable easier grepping of individual process logs. e.g.:

```bash
$  docker logs <containerid> | grep "\[medcattrainer\]"
$  docker logs <containerid> | grep "\[bg-process\]"
$  docker logs <containerid> | grep "\[db-backup\]"
```